### PR TITLE
Treating types inherited from primitives as primitives

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -809,9 +809,9 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
     @Override
     public CodegenModel fromModel(String name, Model model, Map<String, Model> allDefinitions) {
         CodegenModel codegenModel = super.fromModel(name, model, allDefinitions);
-
+        Model parentModel = null;
         if (allDefinitions != null && codegenModel != null && codegenModel.parent != null && codegenModel.hasEnums) {
-            final Model parentModel = allDefinitions.get(codegenModel.parentSchema);
+            parentModel = allDefinitions.get(codegenModel.parentSchema);
             final CodegenModel parentCodegenModel = super.fromModel(codegenModel.parent, parentModel, allDefinitions);
             codegenModel = JavascriptClientCodegen.reconcileInlineEnums(codegenModel, parentCodegenModel);
         }
@@ -828,7 +828,12 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
                 codegenModel.vendorExtensions.put("x-itemType", getSwaggerType(mm.getAdditionalProperties()));
             } else {
                 String type = mm.getType();
-                if (isPrimitiveType(type)){
+                String parentType = null;
+                if (parentModel != null) {
+                    parentType = ((ModelImpl)parentModel).getType();
+                }
+                if (isPrimitiveType(type)
+                    || (parentType != null && isPrimitiveType(parentType))) {
                     codegenModel.vendorExtensions.put("x-isPrimitive", true);
                 }
             }


### PR DESCRIPTION
Javascript codegen produces broken models (not using data at all) for types inherited from primitive types like the following.

```
  ResourceId:
    description: Identifier assigned for further use of the created resource through API calls
    type: string
    pattern: '^([a-zA-Z0-9 /\-?:\()\.,'']{1,35})$'
    readOnly: true
```

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

